### PR TITLE
Properly null check player viewport name when passing to camera manager

### DIFF
--- a/scripts/mods/Spidey Sense/UI/UI.lua
+++ b/scripts/mods/Spidey Sense/UI/UI.lua
@@ -218,6 +218,9 @@ local function get_player_direction_angle()
 	local player = Managers.player:local_player(1)
 
 	local world_viewport_name = player.viewport_name
+    if not world_viewport_name then
+        return
+    end
 
 	local camera_manager = Managers.state.camera
 	local camera = camera_manager:camera(world_viewport_name)


### PR DESCRIPTION
This value can be null, got nil exception in game when switching from training grounds to hub.